### PR TITLE
Add support for multiple worlds

### DIFF
--- a/packages/ecs/src/gadget-ecs.ts
+++ b/packages/ecs/src/gadget-ecs.ts
@@ -1,3 +1,4 @@
+export { default as World } from './lib/World';
 export { default as Entity } from './lib/Entity';
 export { default as Query, QueryProps, QueryResult } from './lib/Query';
 export { default as declareComponent, ComponentDeclaration } from './lib/Component';

--- a/packages/ecs/src/lib/Entity.ts
+++ b/packages/ecs/src/lib/Entity.ts
@@ -10,17 +10,12 @@ import defaultWorld from './defaultWorld';
  * The Entity representation, which can carry mulitple components and appear in {@linkcode Query}s.
  */
 export default class Entity {
-	public static isDestroyed( entity: Entity ): boolean {
-		return entity.isDestroyed;
-	}
-
 	/** ID unique to this entity. */
 	public readonly id: number;
 
 	private components: Record<symbol, unknown> = {};
 	private mutationObservers: Record<symbol, Set<( entity: Entity ) => void>> = {};
 	private lockedMutations: Set<symbol>;
-	private isDestroyed = false;
 
 
 	/**
@@ -335,7 +330,5 @@ export default class Entity {
 
 		this.components = null;
 		this.mutationObservers = null;
-
-		this.isDestroyed = true;
 	}
 }

--- a/packages/ecs/src/lib/Entity.ts
+++ b/packages/ecs/src/lib/Entity.ts
@@ -10,22 +10,26 @@ import defaultWorld from './defaultWorld';
  * The Entity representation, which can carry mulitple components and appear in {@linkcode Query}s.
  */
 export default class Entity {
+	public static isDestroyed( entity: Entity ): boolean {
+		return entity.isDestroyed;
+	}
+
 	/** ID unique to this entity. */
 	public readonly id: number;
 
-	// TODO: make configurable
-	private world = defaultWorld;
 	private components: Record<symbol, unknown> = {};
 	private mutationObservers: Record<symbol, Set<( entity: Entity ) => void>> = {};
 	private lockedMutations: Set<symbol>;
+	private isDestroyed = false;
 
 
 	/**
 	 * Constructs a new {@linkcode Entity} and adds the given components to it.
 	 *
 	 * @param declarations - The components to add.
+	 * @param world - The world to add the entity to.
 	 */
-	public constructor( declarations: ComponentDeclaration[] = []) {
+	public constructor( declarations: ComponentDeclaration[] = [], private world = defaultWorld ) {
 		this.id = this.world.registerEntity( this );
 
 		if ( __DEV_BUILD__ ) {
@@ -160,7 +164,7 @@ export default class Entity {
 			}
 
 			// return a frozen object for pure objects in dev mode to prevent mutation.
-			// This is skipped in prod mode due to pref implications.
+			// This is skipped in prod mode due to perf implications.
 			if ( Object.prototype.toString.call( this.components[symbol]) === '[object Object]' ) {
 				return Object.freeze( { ...( this.components[symbol] as object ) } ) as T;
 			}
@@ -306,5 +310,7 @@ export default class Entity {
 
 		this.components = null;
 		this.mutationObservers = null;
+
+		this.isDestroyed = true;
 	}
 }

--- a/packages/ecs/src/lib/Query.ts
+++ b/packages/ecs/src/lib/Query.ts
@@ -69,8 +69,6 @@ export type QueryResult<P extends QueryProps = QueryProps
  * @typeParam P - The {@linkcode QueryProps} the {@linkcode Query} was constructed with.
  */
 export default class Query<P extends QueryProps = QueryProps> {
-	// TODO: make configurable
-	private world = defaultWorld;
 	private nextResult: QueryResult<P>;
 	private previousResult: QueryResult<P>;
 	private has: ComponentDeclaration[] = [];
@@ -83,13 +81,17 @@ export default class Query<P extends QueryProps = QueryProps> {
 	 * Constructs a new {@linkcode Query}. See {@linkcode QueryProps} for options.
 	 *
 	 * @param param0 - see {@linkcode QueryProps}
+	 * @param world - The world to add the query to.
 	 */
-	public constructor( {
-		has,
-		trackAdded = false,
-		trackRemoved = false,
-		trackMutated,
-	}: P ) {
+	public constructor(
+		{
+			has,
+			trackAdded = false,
+			trackRemoved = false,
+			trackMutated,
+		}: P,
+		private world = defaultWorld,
+	) {
 		this.has = has;
 		this.trackAdded = trackAdded;
 		this.trackRemoved = trackRemoved;

--- a/packages/ecs/src/lib/Query.ts
+++ b/packages/ecs/src/lib/Query.ts
@@ -1,9 +1,13 @@
 import { ComponentDeclaration } from './Component';
 import defaultWorld from './defaultWorld';
 import type Entity from './Entity';
+import type World from './World';
 
 
 export interface QueryProps<C extends ComponentDeclaration[] = ComponentDeclaration[]> {
+	/** The {@linkcode World} that the query will query from. */
+	world?: World
+
 	/** The components an {@linkcode Entity} needs to have to match the {@linkcode Query}. */
 	has: C,
 
@@ -71,6 +75,7 @@ export type QueryResult<P extends QueryProps = QueryProps
 export default class Query<P extends QueryProps = QueryProps> {
 	private nextResult: QueryResult<P>;
 	private previousResult: QueryResult<P>;
+	private world: World;
 	private has: ComponentDeclaration[] = [];
 	private trackAdded: boolean;
 	private trackRemoved: boolean;
@@ -81,17 +86,17 @@ export default class Query<P extends QueryProps = QueryProps> {
 	 * Constructs a new {@linkcode Query}. See {@linkcode QueryProps} for options.
 	 *
 	 * @param param0 - see {@linkcode QueryProps}
-	 * @param world - The world to add the query to.
 	 */
 	public constructor(
 		{
+			world = defaultWorld,
 			has,
 			trackAdded = false,
 			trackRemoved = false,
 			trackMutated,
 		}: P,
-		private world = defaultWorld,
 	) {
+		this.world = world;
 		this.has = has;
 		this.trackAdded = trackAdded;
 		this.trackRemoved = trackRemoved;

--- a/packages/ecs/src/lib/World.test.ts
+++ b/packages/ecs/src/lib/World.test.ts
@@ -7,39 +7,16 @@ describe( 'World', () => {
 	const aComponent = declareComponent( 'a', () => ( { a: 0 } ) );
 	const bComponent = declareComponent( 'b', () => ( { b: 0 } ) );
 
-	it( 'should have a unique id', () => {
-		const worldA = new World( 'A' );
-		const worldB = new World( 'B' );
-
-		expect( worldA.id ).toBe( 'A' );
-		expect( worldB.id ).toBe( 'B' );
-
-		World.destroyAll();
-	} );
-
-	it( 'should generate random id', () => {
-		const world = new World();
-
-		expect( world.id ).not.toBe( undefined );
-		expect( world.id ).not.toBe( null );
-
-		World.destroyAll();
-	} );
-
 	it( 'should destroy', () => {
 		const world = new World();
 
-		expect( World.getWorld( world.id ) ).toBe( world );
-
 		world.destroy();
 
-		expect( World.getWorld( world.id ) ).toBe( undefined );
-
-		World.destroyAll();
+		expect( world.isDestroyed() ).toBe( true );
 	} );
 
 	it( 'should destroy entities', () => {
-		const world = new World( 'A' );
+		const world = new World();
 
 		const entityA = new Entity([], world );
 		const entityB = new Entity([], world );
@@ -49,11 +26,9 @@ describe( 'World', () => {
 
 		world.destroy();
 
-		expect( World.isDestroyed( world ) ).toBe( true );
-		expect( Entity.isDestroyed( entityA ) ).toBe( true );
-		expect( Entity.isDestroyed( entityB ) ).toBe( true );
-
-		World.destroyAll();
+		expect( world.isDestroyed() ).toBe( true );
+		expect( entityA.isDestroyed() ).toBe( true );
+		expect( entityB.isDestroyed() ).toBe( true );
 	} );
 
 	it( 'should throw if destroyed', () => {
@@ -65,7 +40,5 @@ describe( 'World', () => {
 			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 			const entity = new Entity([], world );
 		} ).toThrow();
-
-		World.destroyAll();
 	} );
 } );

--- a/packages/ecs/src/lib/World.test.ts
+++ b/packages/ecs/src/lib/World.test.ts
@@ -61,13 +61,10 @@ describe( 'World', () => {
 
 		world.destroy();
 
-		try {
+		expect( () => {
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 			const entity = new Entity([], world );
-
-			expect( entity ).toBe( entity );
-		} catch ( err ) {
-			expect( true ).toBe( true );
-		}
+		} ).toThrow();
 
 		World.destroyAll();
 	} );

--- a/packages/ecs/src/lib/World.test.ts
+++ b/packages/ecs/src/lib/World.test.ts
@@ -1,0 +1,74 @@
+import declareComponent from './Component';
+import Entity from './Entity';
+import World from './World';
+
+
+describe( 'World', () => {
+	const aComponent = declareComponent( 'a', () => ( { a: 0 } ) );
+	const bComponent = declareComponent( 'b', () => ( { b: 0 } ) );
+
+	it( 'should have a unique id', () => {
+		const worldA = new World( 'A' );
+		const worldB = new World( 'B' );
+
+		expect( worldA.id ).toBe( 'A' );
+		expect( worldB.id ).toBe( 'B' );
+
+		World.destroyAll();
+	} );
+
+	it( 'should generate random id', () => {
+		const world = new World();
+
+		expect( world.id ).not.toBe( undefined );
+		expect( world.id ).not.toBe( null );
+
+		World.destroyAll();
+	} );
+
+	it( 'should destroy', () => {
+		const world = new World();
+
+		expect( World.getWorld( world.id ) ).toBe( world );
+
+		world.destroy();
+
+		expect( World.getWorld( world.id ) ).toBe( undefined );
+
+		World.destroyAll();
+	} );
+
+	it( 'should destroy entities', () => {
+		const world = new World( 'A' );
+
+		const entityA = new Entity([], world );
+		const entityB = new Entity([], world );
+
+		entityA.add( aComponent );
+		entityB.add( bComponent );
+
+		world.destroy();
+
+		expect( World.isDestroyed( world ) ).toBe( true );
+		expect( Entity.isDestroyed( entityA ) ).toBe( true );
+		expect( Entity.isDestroyed( entityB ) ).toBe( true );
+
+		World.destroyAll();
+	} );
+
+	it( 'should throw if destroyed', () => {
+		const world = new World();
+
+		world.destroy();
+
+		try {
+			const entity = new Entity([], world );
+
+			expect( entity ).toBe( entity );
+		} catch ( err ) {
+			expect( true ).toBe( true );
+		}
+
+		World.destroyAll();
+	} );
+} );

--- a/packages/ecs/src/lib/World.ts
+++ b/packages/ecs/src/lib/World.ts
@@ -10,12 +10,35 @@ export interface WithWorld {
  * @internal
  */
 export default class World {
+	private static worlds: { [id: string]: World } = {};
+
+	public static getWorld( id: string ): World | undefined {
+		return this.worlds[id];
+	}
+
+	public static destroyAll(): void {
+		Object.values( this.worlds ).forEach( ( world ) => world.destroy() );
+		this.worlds = {};
+	}
+
+	public static isDestroyed( world: World ): boolean {
+		return world.isDestroyed;
+	}
+
 	private previousEntityId = -1;
 	private entities = new Set<Entity>();
 	private queries = new Set<Query>();
+	private isDestroyed = false;
 
+	public constructor( public readonly id?: string ) {
+		while ( this.id === undefined || this.id === null || World.worlds[id]) {
+			this.id = ( Math.ceil( Math.random() * 99999999999 ) ).toString();
+		}
+		World.worlds[this.id] = this;
+	}
 
 	public registerQuery( query: Query ): void {
+		if ( this.isDestroyed ) { throw new Error( 'The world is already destroyed!' ); }
 		this.queries.add( query );
 		this.entities.forEach( ( entity ) => {
 			query.test( entity );
@@ -23,11 +46,13 @@ export default class World {
 	}
 
 	public unregisterQuery( query: Query ): void {
+		if ( this.isDestroyed ) { throw new Error( 'The world is already destroyed!' ); }
 		this.queries.delete( query );
 	}
 
 
 	public registerEntity( entity: Entity ): number {
+		if ( this.isDestroyed ) { throw new Error( 'The world is already destroyed!' ); }
 		this.entities.add( entity );
 		this.previousEntityId += 1;
 
@@ -37,14 +62,27 @@ export default class World {
 	}
 
 	public unregisterEntity( entity: Entity ): void {
+		if ( this.isDestroyed ) { throw new Error( 'The world is already destroyed!' ); }
 		this.entities.delete( entity );
 		// unregisterEntity is preceeded by entity.remove(),
 		// which calls this.updateQueries
 	}
 
 	public updateQueries( entity: Entity ): void {
+		if ( this.isDestroyed ) { throw new Error( 'The world is already destroyed!' ); }
 		this.queries.forEach( ( query ) => {
 			query.test( entity );
 		} );
+	}
+
+	public destroy(): void {
+		this.queries.forEach( ( query ) => query.destroy() );
+		this.entities.forEach( ( entity ) => entity.destroy() );
+		this.queries = null;
+		this.entities = null;
+
+		delete World.worlds[this.id];
+
+		this.isDestroyed = true;
 	}
 }

--- a/packages/ecs/src/lib/World.ts
+++ b/packages/ecs/src/lib/World.ts
@@ -10,35 +10,12 @@ export interface WithWorld {
  * @internal
  */
 export default class World {
-	private static worlds: { [id: string]: World } = {};
-
-	public static getWorld( id: string ): World | undefined {
-		return this.worlds[id];
-	}
-
-	public static destroyAll(): void {
-		Object.values( this.worlds ).forEach( ( world ) => world.destroy() );
-		this.worlds = {};
-	}
-
-	public static isDestroyed( world: World ): boolean {
-		return world.isDestroyed;
-	}
-
 	private previousEntityId = -1;
 	private entities = new Set<Entity>();
 	private queries = new Set<Query>();
-	private isDestroyed = false;
-
-	public constructor( public readonly id?: string ) {
-		while ( this.id === undefined || this.id === null || World.worlds[id]) {
-			this.id = ( Math.ceil( Math.random() * 99999999999 ) ).toString();
-		}
-		World.worlds[this.id] = this;
-	}
 
 	public registerQuery( query: Query ): void {
-		if ( this.isDestroyed ) { throw new Error( 'The world is already destroyed!' ); }
+		if ( this.isDestroyed() ) { throw new Error( 'The world is already destroyed!' ); }
 		this.queries.add( query );
 		this.entities.forEach( ( entity ) => {
 			query.test( entity );
@@ -46,13 +23,13 @@ export default class World {
 	}
 
 	public unregisterQuery( query: Query ): void {
-		if ( this.isDestroyed ) { throw new Error( 'The world is already destroyed!' ); }
+		if ( this.isDestroyed() ) { throw new Error( 'The world is already destroyed!' ); }
 		this.queries.delete( query );
 	}
 
 
 	public registerEntity( entity: Entity ): number {
-		if ( this.isDestroyed ) { throw new Error( 'The world is already destroyed!' ); }
+		if ( this.isDestroyed() ) { throw new Error( 'The world is already destroyed!' ); }
 		this.entities.add( entity );
 		this.previousEntityId += 1;
 
@@ -62,17 +39,21 @@ export default class World {
 	}
 
 	public unregisterEntity( entity: Entity ): void {
-		if ( this.isDestroyed ) { throw new Error( 'The world is already destroyed!' ); }
+		if ( this.isDestroyed() ) { throw new Error( 'The world is already destroyed!' ); }
 		this.entities.delete( entity );
 		// unregisterEntity is preceeded by entity.remove(),
 		// which calls this.updateQueries
 	}
 
 	public updateQueries( entity: Entity ): void {
-		if ( this.isDestroyed ) { throw new Error( 'The world is already destroyed!' ); }
+		if ( this.isDestroyed() ) { throw new Error( 'The world is already destroyed!' ); }
 		this.queries.forEach( ( query ) => {
 			query.test( entity );
 		} );
+	}
+
+	public isDestroyed(): boolean {
+		return !this.entities;
 	}
 
 	public destroy(): void {
@@ -80,9 +61,5 @@ export default class World {
 		this.entities.forEach( ( entity ) => entity.destroy() );
 		this.queries = null;
 		this.entities = null;
-
-		delete World.worlds[this.id];
-
-		this.isDestroyed = true;
 	}
 }

--- a/packages/ecs/src/lib/defaultWorld.ts
+++ b/packages/ecs/src/lib/defaultWorld.ts
@@ -1,6 +1,6 @@
 import World from './World';
 
 
-const defaultWorld = new World( 'default' );
+const defaultWorld = new World();
 
 export default defaultWorld;

--- a/packages/ecs/src/lib/defaultWorld.ts
+++ b/packages/ecs/src/lib/defaultWorld.ts
@@ -1,6 +1,6 @@
 import World from './World';
 
 
-const defaultWorld = new World();
+const defaultWorld = new World( 'default' );
 
 export default defaultWorld;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2823,9 +2823,9 @@ camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001313:
-  version "1.0.30001315"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001315.tgz#f1b1efd1171ee1170d52709a7252632dacbd7c77"
-  integrity sha512-5v7LFQU4Sb/qvkz7JcZkvtSH1Ko+1x2kgo3ocdBeMGZSOFpuE1kkm0kpTwLtWeFrw5qw08ulLxJjVIXIS8MkiQ==
+  version "1.0.30001397"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001397.tgz"
+  integrity sha512-SW9N2TbCdLf0eiNDRrrQXx2sOkaakNZbCjgNpPyMJJbiOrU5QzMIrXOVMRM1myBXTD5iTkdrtU/EguCrBocHlA==
 
 cardinal@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
It wasn't possible to create a new World instance until now. All entities and queries were using the default world. Now, it is possible to call `new World(id)` and `new Entity(world)`, `new Query(world)`.